### PR TITLE
Atualizar Collect API

### DIFF
--- a/cornice_apispec/autodoc.py
+++ b/cornice_apispec/autodoc.py
@@ -83,11 +83,12 @@ class AutoDoc(object):
                 return source_class.nested if source_class else None
             if validator.__dict__.get('location', '') == location:
                 return request_schema
-            # No valid cornice validator was found
-            # but a validator exists. In this case,
-            # return the request_schema if location is body
-            if location == "body":
-                return request_schema
+
+        # No valid cornice validator was found
+        # but request_schema exists. In this case,
+        # return the nested match schema
+        maybe_nested = request_schema._declared_fields.get(location, None)
+        return maybe_nested.nested if maybe_nested else None
 
     def to_dict(self):
         self.view_operations.setdefault(self.method.lower(), {"responses": {}})

--- a/cornice_apispec/autodoc.py
+++ b/cornice_apispec/autodoc.py
@@ -83,6 +83,11 @@ class AutoDoc(object):
                 return source_class.nested if source_class else None
             if validator.__dict__.get('location', '') == location:
                 return request_schema
+            # No valid cornice validator was found
+            # but a validator exists. In this case,
+            # return the request_schema if location is body
+            if location == "body":
+                return request_schema
 
     def to_dict(self):
         self.view_operations.setdefault(self.method.lower(), {"responses": {}})

--- a/cornice_apispec/operations.py
+++ b/cornice_apispec/operations.py
@@ -4,7 +4,7 @@ from cornice_apispec.autodoc import AutoDoc
 from pyramid_apispec.helpers import ALL_METHODS, is_string
 
 
-def get_operations(spec, view, operations, show_head, autodoc=True):
+def get_operations(spec, view, operations, show_head, show_options, autodoc=True):
     if operations is not None:
         return operations
 
@@ -30,6 +30,8 @@ def get_operations(spec, view, operations, show_head, autodoc=True):
             methods = ALL_METHODS[:]
         if 'HEAD' in methods and not show_head:
             methods.remove('HEAD')
+        if 'OPTIONS' in methods and not show_options:
+            methods.remove('OPTIONS')
         operation = load_yaml_from_docstring(f_view.__doc__)
         if operation:
             for method in methods:

--- a/cornice_apispec/paths.py
+++ b/cornice_apispec/paths.py
@@ -35,6 +35,7 @@ def add_pyramid_paths(
         request = get_current_request()
 
     show_head = kwargs.pop('show_head', False)
+    show_options = kwargs.pop('show_options', True)
     registry = request.registry
     # TODO: This is the original pyramid_apispec introspector use,
     #   getting routes instead of views.
@@ -70,5 +71,6 @@ def add_pyramid_paths(
         pattern = reformat_pattern(pattern)
         spec.path(
             pattern,
-            operations=get_operations(spec, maybe_view, operations, autodoc=autodoc, show_head=show_head)
+            operations=get_operations(spec, maybe_view, operations, autodoc=autodoc, show_head=show_head,
+                                      show_options=show_options)
         )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIREMENTS_DEV = [
 
 setup(
     name="cornice_apispec",
-    version='0.9.6',
+    version='0.9.7',
     description="Generate swagger from a Cornice application",
     long_description=README + "\n\n" + CHANGES,
     license="Apache License (2.0)",


### PR DESCRIPTION
*Reference*: [COLLECTION-2302](https://geruteam.atlassian.net/browse/COLLECTION-2302)

## Geral
No código atual, uma única pagina swagger é gerada para toda a aplicação. Com as modificações abaixo é possível que um sistema gere mais de um swagger automaticamente:
* Adiciona a opção `auto_generate.swagger.view` no **settings**. A opção `True` diz que uma única página será gerada automaticamente. Se estiver `False` é preciso adicionar no `includeme` de cada API os dados de sua pagina swagger.
* Adiciona a opção `filter_by_tags` na **view**. A view só aparece no swagger se a tag que está vinculada a ela estiver na lista de tags daquela página.

### Changes in cornice.ext.apispec
* Add option `filter_by_tags` in *generate_spec*
* Add option `auto_generate.swagger.view` in pyramid settings
* Add option `show_options` in *generate_spec*

Resolves COLLECTION-2302